### PR TITLE
Added additional parameter "routing_group" to config.php.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ To use this library you need create an account with Bulksms. They support severa
 1. Username : Bulksms login
 2. Password : Bulksms login password
 3. Baseurl : Bulksms sub-site to connect to (e.g. "http://bulksms.com" or "http://bulksms.de")
+4. Routing Group : A number between 1 and 3 to indicate the Routing Group used by BulkSMS. See BulkSMS API documentation for more details (http://developer.bulksms.com/eapi/)
 
 ## Usage
 

--- a/resources/config.php
+++ b/resources/config.php
@@ -3,4 +3,5 @@ return array(
     'username' => 'REPLACEME',
     'password' => 'REPLACEME',
     'baseurl' => 'REPLACEME',
+    'routing_group' => 'REPLACEME',
 );

--- a/src/BulkSmsService.php
+++ b/src/BulkSmsService.php
@@ -69,18 +69,24 @@ class BulkSmsService
     protected $baseUrl;
 
     /**
+     * @var integer
+     */
+    protected $routingGroup;
+
+    /**
      * @param string $username BulkSMS username
      * @param string $password BulkSMS password
      * @param string $baseUrl  Optional - defaults to "http://bulksms.vsms.net:5567"
      * @param cURL   $curl     Optional - a new instance will be constructed if null is passed.
      */
-    public function __construct($username, $password, $baseUrl = "http://bulksms.vsms.net:5567", $curl = null)
+    public function __construct($username, $password, $baseUrl = "http://bulksms.vsms.net:5567", $routingGroup = 2, $curl = null)
     {
         v::url()->setName("Base Bulksms URL")->check($baseUrl);
         $this->baseUrl  = $baseUrl;
         $this->username = $username;
         $this->password = $password;
         $this->curl     = $curl ?: new cURL();
+        $this->routingGroup = $routingGroup;
     }
 
     /**
@@ -127,7 +133,7 @@ class BulkSmsService
      */
     protected function createMessageSender()
     {
-        return new Sender\Single($this->username, $this->password, $this->baseUrl, $this->curl);
+        return new Sender\Single($this->username, $this->password, $this->baseUrl, $this->routingGroup, $this->curl);
     }
 
     /**
@@ -234,6 +240,6 @@ class BulkSmsService
      */
     protected function createBulkStatusSender()
     {
-        return new Sender\Status($this->username, $this->password, $this->baseUrl, $this->curl);
+        return new Sender\Status($this->username, $this->password, $this->baseUrl, $this->routingGroup, $this->curl);
     }
 }

--- a/src/BulkSmsService.php
+++ b/src/BulkSmsService.php
@@ -214,7 +214,7 @@ class BulkSmsService
      */
     protected function createBulkSender()
     {
-        return new Sender\Bulk($this->username, $this->password, $this->baseUrl, $this->curl);
+        return new Sender\Bulk($this->username, $this->password, $this->baseUrl, $this->routingGroup, $this->curl);
     }
 
     /**

--- a/src/Laravel/BulkSmsServiceProvider.php
+++ b/src/Laravel/BulkSmsServiceProvider.php
@@ -38,16 +38,18 @@ class BulkSmsServiceProvider extends ServiceProvider
                     $username  = $app['config']->get('bulk-sms.username');
                     $password  = $app['config']->get('bulk-sms.password');
                     $baseurl   = $app['config']->get('bulk-sms.baseurl');
+                    $routinggroup  = $app['config']->get('bulk-sms.routing_group') ?: 2;
                 } else {
                     $username  = $app['config']->get('bulk-sms::username');
                     $password  = $app['config']->get('bulk-sms::password');
                     $baseurl   = $app['config']->get('bulk-sms::baseurl');
+                    $routinggroup  = $app['config']->get('bulk-sms.routing_group') ?: 2;
                 }
 
                 if (isset($app['curl'])) {
-                    return new BulkSmsService($username, $password, $baseurl, $app['curl']);
+                    return new BulkSmsService($username, $password, $baseurl, $routinggroup, $app['curl']);
                 } else {
-                    return new BulkSmsService($username, $password, $baseurl, null);
+                    return new BulkSmsService($username, $password, $baseurl, $routinggroup, null);
                 }
             }
         );

--- a/src/Sender/AbstractSender.php
+++ b/src/Sender/AbstractSender.php
@@ -44,6 +44,13 @@ abstract class AbstractSender
     protected $baseUrl;
 
     /**
+     * The Routing Group
+     *
+     * @var string
+     */
+    protected $routingGroup;
+
+    /**
      * The cURL instance.
      *
      * @var cURL
@@ -56,13 +63,14 @@ abstract class AbstractSender
      * @param        $baseUrl
      * @param cURL   $curl
      */
-    public function __construct($username, $password, $baseUrl, cURL $curl = null)
+    public function __construct($username, $password, $baseUrl, $routingGroup, cURL $curl = null)
     {
         v::url()->setName("Base Bulksms URL")->check($baseUrl);
         $this->baseUrl  = $baseUrl;
         $this->username = $username;
         $this->password = $password;
         $this->curl     = $curl ?: new cURL();
+        $this->routingGroup = $routingGroup;
     }
 
     /**

--- a/src/Sender/Bulk.php
+++ b/src/Sender/Bulk.php
@@ -57,9 +57,10 @@ class Bulk extends AbstractSender
         }
 
         $data = [
-            'username'   => $this->username,
-            'password'   => $this->password,
-            'batch_data' => $this->generateCSV(),
+            'username'      => $this->username,
+            'password'      => $this->password,
+            'batch_data'    => $this->generateCSV(),
+            'routing_group' => $this->routingGroup,
         ];
 
         // add test params if required

--- a/src/Sender/Single.php
+++ b/src/Sender/Single.php
@@ -53,10 +53,11 @@ class Single extends AbstractSender
     public function send($testmode = false)
     {
         $data = [
-            'username' => $this->username,
-            'password' => $this->password,
-            'message'  => $this->message->getMessage(),
-            'msisdn'   => $this->message->getRecipient(),
+            'username'      => $this->username,
+            'password'      => $this->password,
+            'message'       => $this->message->getMessage(),
+            'msisdn'        => $this->message->getRecipient(),
+            'routing_group' => $this->routingGroup,
         ];
 
         $concat = $this->message->getConcatParts();

--- a/tests/Sender/BulkSmsServiceGetStatusTest.php
+++ b/tests/Sender/BulkSmsServiceGetStatusTest.php
@@ -24,7 +24,7 @@ class BulkSmsServiceGetStatusTest extends PHPUnit_Framework_TestCase
             'http://bulksms.vsms.net:5567/eapi/status_reports/get_report/2/2.0',
             $expectedGetData
         )->andReturn($mockResponse);
-        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', $curl);
+        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', 2, $curl);
         $this->assertEquals(
             array(array('msisdn' => '1212121', 'status_code' => '11')),
             $bsms->getStatusForBatchId('123445566')
@@ -36,9 +36,9 @@ class BulkSmsServiceGetStatusTest extends PHPUnit_Framework_TestCase
         return m::mock('anlutro\cURL\cURL');
     }
 
-    public function makeService($username, $password, $baseurl, $curl = null)
+    public function makeService($username, $password, $baseurl, $routingGroup = 2, $curl = null)
     {
-        return new anlutro\BulkSms\BulkSmsService($username, $password, $baseurl, $curl);
+        return new anlutro\BulkSms\BulkSmsService($username, $password, $baseurl, $routingGroup, $curl);
     }
 
     public function testMultipleResponseSuccess()
@@ -58,7 +58,7 @@ class BulkSmsServiceGetStatusTest extends PHPUnit_Framework_TestCase
             'http://bulksms.vsms.net:5567/eapi/status_reports/get_report/2/2.0',
             $expectedGetData
         )->andReturn($mockResponse);
-        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', $curl);
+        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', 2, $curl);
         $this->assertEquals(
             array(
                 array('msisdn' => '1212121', 'status_code' => '11'),
@@ -84,7 +84,7 @@ class BulkSmsServiceGetStatusTest extends PHPUnit_Framework_TestCase
             'http://bulksms.vsms.net:5567/eapi/status_reports/get_report/2/2.0',
             $expectedGetData
         )->andReturn($mockResponse);
-        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', $curl);
+        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', 2, $curl);
         $this->assertEquals(array(), $bsms->getStatusForBatchId('123445566'));
     }
 
@@ -107,7 +107,7 @@ class BulkSmsServiceGetStatusTest extends PHPUnit_Framework_TestCase
             'http://bulksms.vsms.net:5567/eapi/status_reports/get_report/2/2.0',
             $expectedGetData
         )->andReturn($mockResponse);
-        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', $curl);
+        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', 2, $curl);
         $bsms->getStatusForBatchId('123445566');
     }
 
@@ -129,7 +129,7 @@ class BulkSmsServiceGetStatusTest extends PHPUnit_Framework_TestCase
             'http://bulksms.vsms.net:5567/eapi/status_reports/get_report/2/2.0',
             $expectedGetData
         )->andReturn($mockResponse);
-        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', $curl);
+        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', 2, $curl);
         $this->assertTrue($bsms->getStatusForBatchId('123445566'));
     }
 
@@ -149,7 +149,7 @@ class BulkSmsServiceGetStatusTest extends PHPUnit_Framework_TestCase
             'http://bulksms.de/eapi/status_reports/get_report/2/2.0',
             $expectedGetData
         )->andReturn($mockResponse);
-        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.de', $curl);
+        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.de', 2, $curl);
         $this->assertEquals(
             array(array('msisdn' => '1212121', 'status_code' => '11')),
             $bsms->getStatusForBatchId('123445566')

--- a/tests/Sender/BulkSmsServiceSendBatchMessageTest.php
+++ b/tests/Sender/BulkSmsServiceSendBatchMessageTest.php
@@ -15,7 +15,7 @@ class BulkSmsServiceSendBatchMessageTest extends PHPUnit_Framework_TestCase
     public function testSendNoMessageSuccess()
     {
         $curl = $this->mockCurl();
-        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', $curl);
+        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', 2, $curl);
         $this->assertEquals(
             array('status_code' => 0, 'status_description' => "IN_PROGRESS", 'batch_id' => 4712345678),
             $bsms->sendBulkMessages(array())
@@ -27,9 +27,9 @@ class BulkSmsServiceSendBatchMessageTest extends PHPUnit_Framework_TestCase
         return m::mock('anlutro\cURL\cURL');
     }
 
-    public function makeService($username, $password, $baseurl, $curl = null)
+    public function makeService($username, $password, $baseurl, $routingGroup = 2, $curl = null)
     {
-        return new anlutro\BulkSms\BulkSmsService($username, $password, $baseurl, $curl);
+        return new anlutro\BulkSms\BulkSmsService($username, $password, $baseurl, $routingGroup, $curl);
     }
 
     /**
@@ -39,7 +39,7 @@ class BulkSmsServiceSendBatchMessageTest extends PHPUnit_Framework_TestCase
     public function testSendWrongMessageClassSuccess()
     {
         $curl = $this->mockCurl();
-        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', $curl);
+        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', 2, $curl);
         $this->assertEquals(
             array('status_code' => 0, 'status_description' => "IN_PROGRESS", 'batch_id' => 4712345678),
             $bsms->sendBulkMessages(array(m::mock('anlutro\cURL\Response')))
@@ -52,6 +52,7 @@ class BulkSmsServiceSendBatchMessageTest extends PHPUnit_Framework_TestCase
             'username'   => 'foo',
             'password'   => 'bar',
             'batch_data' => "msisdn,message\n\"4917610908093\",\"TestText\"",
+            'routing_group' => 2,
         );
         $mockResponse       = m::mock('anlutro\cURL\Response');
         $mockResponse->code = '200 OK';
@@ -61,7 +62,7 @@ class BulkSmsServiceSendBatchMessageTest extends PHPUnit_Framework_TestCase
             "http://bulksms.vsms.net:5567/eapi/submission/send_batch/1/1.0",
             $expectedPostData
         )->andReturn($mockResponse);
-        $bsms    = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', $curl);
+        $bsms    = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', 2, $curl);
         $message = new \anlutro\BulkSms\Message("4917610908093", "TestText");
         $this->assertEquals(
             array('status_code' => 0, 'status_description' => "IN_PROGRESS", 'batch_id' => 4712345678),
@@ -75,6 +76,7 @@ class BulkSmsServiceSendBatchMessageTest extends PHPUnit_Framework_TestCase
             'username'   => 'foo',
             'password'   => 'bar',
             'batch_data' => "msisdn,message\n\"4917610908093\",\"TestText\"\n\"4917610908094\",\"TestText2\"",
+            'routing_group' => 2,
         );
         $mockResponse       = m::mock('anlutro\cURL\Response');
         $mockResponse->code = '200 OK';
@@ -84,7 +86,7 @@ class BulkSmsServiceSendBatchMessageTest extends PHPUnit_Framework_TestCase
             "http://bulksms.vsms.net:5567/eapi/submission/send_batch/1/1.0",
             $expectedPostData
         )->andReturn($mockResponse);
-        $bsms     = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', $curl);
+        $bsms     = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', 2, $curl);
         $message1 = new \anlutro\BulkSms\Message("4917610908093", "TestText");
         $message2 = new \anlutro\BulkSms\Message("4917610908094", "TestText2");
         $this->assertEquals(

--- a/tests/Sender/BulkSmsServiceSendSingleMessageTest.php
+++ b/tests/Sender/BulkSmsServiceSendSingleMessageTest.php
@@ -15,6 +15,7 @@ class BulkSmsServiceSendSingleMessageTest extends PHPUnit_Framework_TestCase
             'password' => 'bar',
             'message'  => 'hello',
             'msisdn'   => '4712345678',
+            'routing_group' => 2,
         );
         $mockResponse       = m::mock('anlutro\cURL\Response');
         $mockResponse->code = '200 OK';
@@ -24,7 +25,7 @@ class BulkSmsServiceSendSingleMessageTest extends PHPUnit_Framework_TestCase
             'http://bulksms.vsms.net:5567/eapi/submission/send_sms/2/2.0',
             $expectedPostData
         )->andReturn($mockResponse);
-        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', $curl);
+        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', 2, $curl);
 
         $this->assertEquals(
             array('status_code' => 0, 'status_description' => "IN_PROGRESS", 'batch_id' => 4712345678),
@@ -37,9 +38,9 @@ class BulkSmsServiceSendSingleMessageTest extends PHPUnit_Framework_TestCase
         return m::mock('anlutro\cURL\cURL');
     }
 
-    public function makeService($username, $password, $baseurl, $curl = null)
+    public function makeService($username, $password, $baseurl, $routingGroup = 2, $curl = null)
     {
-        return new anlutro\BulkSms\BulkSmsService($username, $password, $baseurl, $curl);
+        return new anlutro\BulkSms\BulkSmsService($username, $password, $baseurl, $routingGroup, $curl);
     }
 
     /**
@@ -52,12 +53,13 @@ class BulkSmsServiceSendSingleMessageTest extends PHPUnit_Framework_TestCase
             'password' => 'bar',
             'message'  => 'hello',
             'msisdn'   => '4712345678',
+            'routing_group' => 2,
         );
         $mockResponse       = m::mock('anlutro\cURL\Response');
         $mockResponse->code = '500';
         $curl               = $this->mockCurl();
         $curl->shouldReceive('post')->once()->andReturn($mockResponse);
-        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', $curl);
+        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', 2, $curl);
 
         $bsms->sendMessage('4712345678', 'hello');
     }
@@ -72,13 +74,14 @@ class BulkSmsServiceSendSingleMessageTest extends PHPUnit_Framework_TestCase
             'password' => 'bar',
             'message'  => 'hello',
             'msisdn'   => '4712345678',
+            'routing_group' => 2,
         );
         $mockResponse       = m::mock('anlutro\cURL\Response');
         $mockResponse->code = '200 OK';
         $mockResponse->body = '99|ERROR|12345678';
         $curl               = $this->mockCurl();
         $curl->shouldReceive('post')->once()->andReturn($mockResponse);
-        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', $curl);
+        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', 2, $curl);
 
         $bsms->sendMessage('23712345678', 'hello');
     }
@@ -93,6 +96,7 @@ class BulkSmsServiceSendSingleMessageTest extends PHPUnit_Framework_TestCase
             'msisdn'                    => '4712345678',
             'allow_concat_text_sms'     => 1,
             'concat_text_sms_max_parts' => 2,
+            'routing_group' => 2,
         );
         $mockResponse       = m::mock('anlutro\cURL\Response');
         $mockResponse->code = '200 OK';
@@ -102,7 +106,7 @@ class BulkSmsServiceSendSingleMessageTest extends PHPUnit_Framework_TestCase
             'http://bulksms.vsms.net:5567/eapi/submission/send_sms/2/2.0',
             $expectedPostData
         )->andReturn($mockResponse);
-        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', $curl);
+        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.vsms.net:5567', 2, $curl);
 
         $this->assertEquals(
             array('status_code' => 0, 'status_description' => "IN_PROGRESS", 'batch_id' => 4712345678),
@@ -120,6 +124,7 @@ class BulkSmsServiceSendSingleMessageTest extends PHPUnit_Framework_TestCase
             'msisdn'                    => '4712345678',
             'allow_concat_text_sms'     => 1,
             'concat_text_sms_max_parts' => 2,
+            'routing_group' => 2,
         );
         $mockResponse       = m::mock('anlutro\cURL\Response');
         $mockResponse->code = '200 OK';
@@ -129,7 +134,7 @@ class BulkSmsServiceSendSingleMessageTest extends PHPUnit_Framework_TestCase
             'http://bulksms.de/eapi/submission/send_sms/2/2.0',
             $expectedPostData
         )->andReturn($mockResponse);
-        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.de', $curl);
+        $bsms = $this->makeService('foo', 'bar', 'http://bulksms.de', 2, $curl);
         $this->assertEquals(
             array('status_code' => 0, 'status_description' => "IN_PROGRESS", 'batch_id' => 4712345678),
             $bsms->sendMessage('4712345678', $message)


### PR DESCRIPTION
I needed to add the routing_group parameter to allow me to specify a higher priority for messages. BulkSMS messages were taking a long time to come through on the default routing_group (over an hour). I've set the default value to 2 which is the same as documented by BulkSMS. I have only added the parameter to the config and classes, I have not updated the documentation or tests. Can this be added to the main branch? Maybe the package can be modified to allow any additional options to be passed through config.php and/or through an array parameter, then users can add any options they need without changing any code?

thanks,

Paul
